### PR TITLE
add baxter_msgs build dependency

### DIFF
--- a/baxter_pick_place/package.xml
+++ b/baxter_pick_place/package.xml
@@ -23,6 +23,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>baxter_control</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>baxter_msgs</build_depend>
 
   <!--run_depend>moveit_core</run_depend>
   <run_depend>moveit_ros_planning</run_depend>


### PR DESCRIPTION
i followed the instructions here: https://github.com/davetcoleman/baxter/tree/groovy-devel  and found that I needed to add this build dependency in order to avoid what appeared to be a build-time race condition where it tried to build baxter_pick_place before it built baxter_msgs. probably depends on the number of cores on the build box, etc.
